### PR TITLE
Let slashes work.

### DIFF
--- a/includes/link.inc
+++ b/includes/link.inc
@@ -102,7 +102,7 @@ function islandora_manuscript_link_to_finding_aid_form($form, &$form_state, Abst
     ),
   );
   if (module_exists('islandora_solr')) {
-    $form['finding_aid']['#autocomplete_path'] = 'islandora_manuscript/autocomplete/finding_aid';
+    $form['finding_aid']['#autocomplete_path'] = 'islandora/manuscript/autocomplete/finding_aid';
   }
 
   if (isset($object)) {

--- a/islandora_manuscript.module
+++ b/islandora_manuscript.module
@@ -118,10 +118,12 @@ function islandora_manuscript_menu() {
       'file path' => drupal_get_path('module', 'islandora_paged_content'),
       'file' => 'includes/manage_page.inc',
     ),
-    'islandora_manuscript/autocomplete/finding_aid' => array(
+    'islandora/manuscript/autocomplete/finding_aid/%menu_tail' => array(
       'title' => 'Finding Aid Autocomplete Callback',
       'page callback' => 'islandora_manuscript_autocomplete_finding_aid',
+      'page arguments' => array(3),
       'access arguments' => array(ISLANDORA_VIEW_OBJECTS),
+      'load arguments' => array('%map', '%index'),
       'file' => 'includes/link.inc',
       'type' => MENU_CALLBACK,
     ),


### PR DESCRIPTION
Drupal core is weird, and unexpected things happen... The path we end up
validating against when trying to make the autocomplete path now is
"islandora", instead of our actual path... Seems kinda... bad.

... Grumble, rawr, words and stuff.
