### PR TITLE
Issue #51, modified default_value to /mixed material/ for manuscript …

### DIFF
--- a/data/forms/islandora_manuscript_form_mods.xml
+++ b/data/forms/islandora_manuscript_form_mods.xml
@@ -257,7 +257,7 @@
         <properties>
           <type>select</type>
           <access>TRUE</access>
-          <default_value>still image</default_value>
+          <default_value>mixed material</default_value>
           <options>
             <text>text</text>
             <cartographic>cartographic</cartographic>


### PR DESCRIPTION
What does this Pull Request do?

Updates the default value for typeOfResource from "still image" to "mixed material".  This value is used when creating new Manuscript objects.

How should this be tested?

1. Look at the MODS for an existing Manuscript object (it would be typeOfResource = "still image").
2. Create a new Manuscript object.
3. Look for typeOfResource = "mixed material" in the MODS of the new object.  

Background context:

Additional Notes:

Does this change require documentation to be updated? No.
Does this change add any new dependencies? No.
Does this change require any other modifications to be made to the repository? It could.  Any manuscript objects created before this may need to be updated to typeOfResource = "mixed material".
Could this change impact execution of existing code? Yes.  It depends on the code.  For example, the Solr Facets on this field would display results of new manuscript objects under the "mixed material" grouping - while old manuscript objects would still be "still image".


Brian Gillingham
Developer
ulsdevteam - University of Pittsburgh