### PR TITLE
Adding new viewer params

### DIFF
--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -56,6 +56,10 @@ function template_preprocess_islandora_manuscript_page(array &$variables) {
       'absolute' => TRUE,
       'query' => array('token' => $token),
     ));
+    $params['token'] = $token;
+    $params['pid'] = $object->id;
+    $params['dsid'] = 'JP2';
+    // Can be removed after 7.x-1.11 is out the door islandora_deprecated.
     $params['jp2_url'] = $jp2_url;
   }
 


### PR DESCRIPTION
As per https://github.com/Islandora/islandora_solution_pack_newspaper/pull/156, https://github.com/Islandora/islandora_solution_pack_large_image/pull/179 & https://github.com/Islandora/islandora_solution_pack_book/pull/200 we should be using the new viewer params to prevent the warnings from popping up.